### PR TITLE
Modify escape function

### DIFF
--- a/.github/workflows/ruleset-checks-sniffs.yml
+++ b/.github/workflows/ruleset-checks-sniffs.yml
@@ -125,14 +125,7 @@ jobs:
         uses: ramsey/composer-install@v1
 
       - name: Test the Eightshift ruleset
-        run: |
-          $(pwd)/vendor/bin/phpcs -ps ./Tests/RulesetCheck/RulesetTest.inc --standard=Eightshift
-          $(pwd)/vendor/bin/phpcs -ps ./Tests/RulesetCheck/RulesetTest2.inc --standard=Eightshift
-          $(pwd)/vendor/bin/phpcs -ps ./Tests/RulesetCheck/RulesetTest3.inc --standard=Eightshift
-          $(pwd)/vendor/bin/phpcs -ps ./Tests/RulesetCheck/RulesetTest4.inc --standard=Eightshift
-          $(pwd)/vendor/bin/phpcs -ps ./Tests/RulesetCheck/RulesetTest5.inc --standard=Eightshift
-          $(pwd)/vendor/bin/phpcs -ps ./Tests/RulesetCheck/RulesetTest6.inc --standard=Eightshift
-          $(pwd)/vendor/bin/phpcs -ps ./Tests/RulesetCheck/RulesetTest7.inc --standard=Eightshift
+        run: composer tests:checkcs
 
       # Test for fixer conflicts by running the auto-fixers of the complete WPCS over the test case files.
       # This is not an exhaustive test, but should give an early indication for typical fixer conflicts.

--- a/.github/workflows/ruleset-checks-sniffs.yml
+++ b/.github/workflows/ruleset-checks-sniffs.yml
@@ -132,6 +132,7 @@ jobs:
           $(pwd)/vendor/bin/phpcs -ps ./Tests/RulesetCheck/RulesetTest4.inc --standard=Eightshift
           $(pwd)/vendor/bin/phpcs -ps ./Tests/RulesetCheck/RulesetTest5.inc --standard=Eightshift
           $(pwd)/vendor/bin/phpcs -ps ./Tests/RulesetCheck/RulesetTest6.inc --standard=Eightshift
+          $(pwd)/vendor/bin/phpcs -ps ./Tests/RulesetCheck/RulesetTest7.inc --standard=Eightshift
 
       # Test for fixer conflicts by running the auto-fixers of the complete WPCS over the test case files.
       # This is not an exhaustive test, but should give an early indication for typical fixer conflicts.

--- a/Eightshift/Docs/Security/CustomEscapeOutputStandard.xml
+++ b/Eightshift/Docs/Security/CustomEscapeOutputStandard.xml
@@ -1,0 +1,23 @@
+<documentation title="Modified Escape Output">
+    <standard>
+    <![CDATA[
+      The original escaping sniff doesn't recognize the static methods as a part of escaping functions.
+      The following implementation will add eightshift libs specific Components::render method to a
+      safe list when sniffing the codebase.
+    ]]>
+    </standard>
+    <code_comparison>
+        <code title="Valid: Using Components::render won't trigger sniff, and doesn't have to be escaped">
+        <![CDATA[
+use EightshiftLibs\Helpers\Components;
+echo Components::render('paragraph', []);
+        ]]>
+        </code>
+        <code title="Invalid: Using other Components helpers require escaping">
+        <![CDATA[
+use EightshiftLibs\Helpers\Components;
+echo Components::classnames(['my-class']);
+        ]]>
+        </code>
+    </code_comparison>
+</documentation>

--- a/Eightshift/Sniffs/Security/CustomEscapeOutputSniff.php
+++ b/Eightshift/Sniffs/Security/CustomEscapeOutputSniff.php
@@ -85,11 +85,6 @@ class CustomEscapeOutputSniff extends EscapeOutputSniff
 			}
 		}
 
-		// Checking for the ignore comment, ex: //xss ok.
-		if ($this->has_whitelist_comment('xss', $stackPtr)) {
-			return;
-		}
-
 		if (isset($this->unsafePrintingFunctions[$function])) {
 			$error = $this->phpcsFile->addError(
 				"All output should be run through an escaping function (like %s), found '%s'.",

--- a/Eightshift/Sniffs/Security/CustomEscapeOutputSniff.php
+++ b/Eightshift/Sniffs/Security/CustomEscapeOutputSniff.php
@@ -1,0 +1,20 @@
+<?php
+
+/**
+ * Eightshift coding standards for WordPress
+ *
+ * @package EightshiftCS
+ *
+ * @author  Eightshift <team@eightshift.com>
+ * @license MIT https://github.com/infinum/coding-standards-wp/blob/master/LICENSE
+ * @link    https://github.com/infinum/coding-standards-wp
+ *
+ * @since 1.0.0 Removed the Tokens util. Modified the warning code
+ * @since 0.4.2 Renamed the WPCS namespace - changed in v2.0.0 of WPCS
+ * @since 0.3.0 Updated sniff to be compatible with latest PHPCS and WPCS
+ * @since 0.1.0
+ */
+
+namespace EightshiftCS\Eightshift\Sniffs\Shortcodes;
+
+use WordPressCS\WordPress\Sniff;

--- a/Eightshift/Sniffs/Security/CustomEscapeOutputSniff.php
+++ b/Eightshift/Sniffs/Security/CustomEscapeOutputSniff.php
@@ -6,15 +6,352 @@
  * @package EightshiftCS
  *
  * @author  Eightshift <team@eightshift.com>
- * @license MIT https://github.com/infinum/coding-standards-wp/blob/master/LICENSE
- * @link    https://github.com/infinum/coding-standards-wp
+ * @license https://opensource.org/licenses/MIT MIT
+ * @link    https://github.com/infinum/eightshift-coding-standards
  *
- * @since 1.0.0 Removed the Tokens util. Modified the warning code
- * @since 0.4.2 Renamed the WPCS namespace - changed in v2.0.0 of WPCS
- * @since 0.3.0 Updated sniff to be compatible with latest PHPCS and WPCS
- * @since 0.1.0
+ * @since 1.2.0
  */
 
-namespace EightshiftCS\Eightshift\Sniffs\Shortcodes;
+namespace EightshiftCS\Eightshift\Sniffs\Security;
 
-use WordPressCS\WordPress\Sniff;
+use PHP_CodeSniffer\Util\Tokens;
+use WordPressCS\WordPress\Sniffs\Security\EscapeOutputSniff;
+
+/**
+ * Escapes all strings with custom exceptions
+ *
+ * The EscapeOutputSniff has customizable properties added to it, but there is an issue
+ * with the sniff at the moment. Because of the issue, it's not possible to specify
+ * static methods as custom escape functions in the sniff.
+ *
+ * Eightshift libs depend heavily on the Components::render method which will echo out
+ * a specific component. This output must not be escaped, as that may cause breakage in the
+ * output (stripped attributes, etc.).
+ *
+ * This sniff will extend the original one, but allow this specific method to be marked as safe.
+ * Other helpers such as Components::classnames, or Components::ensureString should still be escaped.
+ *
+ * @link https://github.com/WordPress/WordPress-Coding-Standards/issues/1176#issuecomment-784045848
+ */
+class CustomEscapeOutputSniff extends EscapeOutputSniff
+{
+	/**
+	 * Processes this test, when one of its tokens is encountered.
+	 *
+	 * @param int $stackPtr The position of the current token in the stack.
+	 *
+	 * @return int|void Integer stack pointer to skip forward or void to continue
+	 *                  normal file processing.
+	 */
+	public function process_token($stackPtr)
+	{
+		$this->mergeFunctionLists();
+
+		$function = $this->tokens[ $stackPtr ]['content'];
+
+		// Find the opening parenthesis (if present; T_ECHO might not have it).
+		$open_paren = $this->phpcsFile->findNext( Tokens::$emptyTokens, ( $stackPtr + 1 ), null, true );
+
+		// If function, not T_ECHO nor T_PRINT.
+		if ( \T_STRING === $this->tokens[ $stackPtr ]['code'] ) {
+			// Skip if it is a function but is not one of the printing functions.
+			if ( ! isset( $this->printingFunctions[ $this->tokens[ $stackPtr ]['content'] ] ) ) {
+				return;
+			}
+
+			if ( isset( $this->tokens[ $open_paren ]['parenthesis_closer'] ) ) {
+				$end_of_statement = $this->tokens[ $open_paren ]['parenthesis_closer'];
+			}
+
+			// These functions only need to have the first argument escaped.
+			if ( \in_array( $function, array( 'trigger_error', 'user_error' ), true ) ) {
+				$first_param      = $this->get_function_call_parameter( $stackPtr, 1 );
+				$end_of_statement = ( $first_param['end'] + 1 );
+				unset( $first_param );
+			}
+
+			/*
+			 * If the first param to `_deprecated_file()` follows the typical `basename( __FILE__ )`
+			 * pattern, it doesn't need to be escaped.
+			 */
+			if ( '_deprecated_file' === $function ) {
+				$first_param = $this->get_function_call_parameter( $stackPtr, 1 );
+
+				// Quick check. This disregards comments.
+				if ( preg_match( '`^basename\s*\(\s*__FILE__\s*\)$`', $first_param['raw'] ) === 1 ) {
+					$stackPtr = ( $first_param['end'] + 2 );
+				}
+				unset( $first_param );
+			}
+		}
+
+		// Checking for the ignore comment, ex: //xss ok.
+		if ( $this->has_whitelist_comment( 'xss', $stackPtr ) ) {
+			return;
+		}
+
+		if ( isset( $this->unsafePrintingFunctions[ $function ] ) ) {
+			$error = $this->phpcsFile->addError(
+				"All output should be run through an escaping function (like %s), found '%s'.",
+				$stackPtr,
+				'UnsafePrintingFunction',
+				array( $this->unsafePrintingFunctions[ $function ], $function )
+			);
+
+			// If the error was reported, don't bother checking the function's arguments.
+			if ( $error ) {
+				return $end_of_statement ?? null;
+			}
+		}
+
+		$ternary = false;
+
+		// This is already determined if this is a function and not T_ECHO.
+		if ( ! isset( $end_of_statement ) ) {
+
+			$end_of_statement = $this->phpcsFile->findNext( array( \T_SEMICOLON, \T_CLOSE_TAG ), $stackPtr );
+			$last_token       = $this->phpcsFile->findPrevious( Tokens::$emptyTokens, ( $end_of_statement - 1 ), null, true );
+
+			// Check for the ternary operator. We only need to do this here if this
+			// echo is lacking parenthesis. Otherwise it will be handled below.
+			if ( \T_OPEN_PARENTHESIS !== $this->tokens[ $open_paren ]['code'] || \T_CLOSE_PARENTHESIS !== $this->tokens[ $last_token ]['code'] ) {
+
+				$ternary = $this->phpcsFile->findNext( \T_INLINE_THEN, $stackPtr, $end_of_statement );
+
+				// If there is a ternary skip over the part before the ?. However, if
+				// the ternary is within parentheses, it will be handled in the loop.
+				if ( false !== $ternary && empty( $this->tokens[ $ternary ]['nested_parenthesis'] ) ) {
+					$stackPtr = $ternary;
+				}
+			}
+		}
+
+		// Ignore the function itself.
+		$stackPtr++;
+
+		$in_cast = false;
+
+		// Looping through echo'd components.
+		$watch = true;
+		for ( $i = $stackPtr; $i < $end_of_statement; $i++ ) {
+
+			// Ignore whitespaces and comments.
+			if ( isset( Tokens::$emptyTokens[ $this->tokens[ $i ]['code'] ] ) ) {
+				continue;
+			}
+
+			// Ignore namespace separators.
+			if ( \T_NS_SEPARATOR === $this->tokens[ $i ]['code'] ) {
+				continue;
+			}
+
+			if ( \T_OPEN_PARENTHESIS === $this->tokens[ $i ]['code'] ) {
+
+				if ( ! isset( $this->tokens[ $i ]['parenthesis_closer'] ) ) {
+					// Live coding or parse error.
+					break;
+				}
+
+				if ( $in_cast ) {
+
+					// Skip to the end of a function call if it has been casted to a safe value.
+					$i       = $this->tokens[ $i ]['parenthesis_closer'];
+					$in_cast = false;
+
+				} else {
+
+					// Skip over the condition part of a ternary (i.e., to after the ?).
+					$ternary = $this->phpcsFile->findNext( \T_INLINE_THEN, $i, $this->tokens[ $i ]['parenthesis_closer'] );
+
+					if ( false !== $ternary ) {
+
+						$next_paren = $this->phpcsFile->findNext( \T_OPEN_PARENTHESIS, ( $i + 1 ), $this->tokens[ $i ]['parenthesis_closer'] );
+
+						// We only do it if the ternary isn't within a subset of parentheses.
+						if ( false === $next_paren || ( isset( $this->tokens[ $next_paren ]['parenthesis_closer'] ) && $ternary > $this->tokens[ $next_paren ]['parenthesis_closer'] ) ) {
+							$i = $ternary;
+						}
+					}
+				}
+
+				continue;
+			}
+
+			// Handle arrays for those functions that accept them.
+			if ( \T_ARRAY === $this->tokens[ $i ]['code'] ) {
+				$i++; // Skip the opening parenthesis.
+				continue;
+			}
+
+			if ( \T_OPEN_SHORT_ARRAY === $this->tokens[ $i ]['code']
+				|| \T_CLOSE_SHORT_ARRAY === $this->tokens[ $i ]['code']
+			) {
+				continue;
+			}
+
+			if ( \in_array( $this->tokens[ $i ]['code'], array( \T_DOUBLE_ARROW, \T_CLOSE_PARENTHESIS ), true ) ) {
+				continue;
+			}
+
+			// Handle magic constants for debug functions.
+			if ( isset( $this->magic_constant_tokens[ $this->tokens[ $i ]['type'] ] ) ) {
+				continue;
+			}
+
+			// Handle safe PHP native constants.
+			if ( \T_STRING === $this->tokens[ $i ]['code']
+				&& isset( $this->safe_php_constants[ $this->tokens[ $i ]['content'] ] )
+				&& $this->is_use_of_global_constant( $i )
+			) {
+				continue;
+			}
+
+			// Wake up on concatenation characters, another part to check.
+			if ( \T_STRING_CONCAT === $this->tokens[ $i ]['code'] ) {
+				$watch = true;
+				continue;
+			}
+
+			// Wake up after a ternary else (:).
+			if ( false !== $ternary && \T_INLINE_ELSE === $this->tokens[ $i ]['code'] ) {
+				$watch = true;
+				continue;
+			}
+
+			// Wake up for commas.
+			if ( \T_COMMA === $this->tokens[ $i ]['code'] ) {
+				$in_cast = false;
+				$watch   = true;
+				continue;
+			}
+
+			if ( false === $watch ) {
+				continue;
+			}
+
+			// Allow T_CONSTANT_ENCAPSED_STRING eg: echo 'Some String';
+			// Also T_LNUMBER, e.g.: echo 45; exit -1; and booleans.
+			if ( isset( $this->safe_components[ $this->tokens[ $i ]['type'] ] ) ) {
+				continue;
+			}
+
+			$watch = false;
+
+			// Allow int/double/bool casted variables.
+			if ( isset( $this->safe_casts[ $this->tokens[ $i ]['code'] ] ) ) {
+				$in_cast = true;
+				continue;
+			}
+
+			// Now check that next token is a function call.
+			if ( \T_STRING === $this->tokens[ $i ]['code'] ) {
+
+				$ptr                    = $i;
+				$functionName           = $this->tokens[ $i ]['content'];
+				$function_opener        = $this->phpcsFile->findNext( \T_OPEN_PARENTHESIS, ( $i + 1 ), null, false, null, true );
+				$is_formatting_function = isset( $this->formattingFunctions[ $functionName ] );
+
+				if ( false !== $function_opener ) {
+
+					if ( isset( $this->arrayWalkingFunctions[ $functionName ] ) ) {
+
+						// Get the callback parameter.
+						$callback = $this->get_function_call_parameter(
+							$ptr,
+							$this->arrayWalkingFunctions[ $functionName ]
+						);
+
+						if ( ! empty( $callback ) ) {
+							/*
+							 * If this is a function callback (not a method callback array) and we're able
+							 * to resolve the function name, do so.
+							 */
+							$mapped_function = $this->phpcsFile->findNext(
+								Tokens::$emptyTokens,
+								$callback['start'],
+								( $callback['end'] + 1 ),
+								true
+							);
+
+							if ( false !== $mapped_function
+								&& \T_CONSTANT_ENCAPSED_STRING === $this->tokens[ $mapped_function ]['code']
+							) {
+								$functionName = $this->strip_quotes( $this->tokens[ $mapped_function ]['content'] );
+								$ptr          = $mapped_function;
+							}
+						}
+					}
+
+					// Skip pointer to after the function.
+					// If this is a formatting function we just skip over the opening
+					// parenthesis. Otherwise we skip all the way to the closing.
+					if ( $is_formatting_function ) {
+						$i     = ( $function_opener + 1 );
+						$watch = true;
+					} else {
+						if ( isset( $this->tokens[ $function_opener ]['parenthesis_closer'] ) ) {
+							$i = $this->tokens[ $function_opener ]['parenthesis_closer'];
+						} else {
+							// Live coding or parse error.
+							break;
+						}
+					}
+				}
+
+				// If this is a safe function, we don't flag it.
+				if (
+					$is_formatting_function
+					|| isset( $this->autoEscapedFunctions[ $functionName ] )
+					|| isset( $this->escapingFunctions[ $functionName ] )
+				) {
+					continue;
+				}
+
+				$content = $functionName;
+			} else {
+				$content = $this->tokens[ $i ]['content'];
+				$ptr     = $i;
+			}
+
+			$componentsFound = false;
+			if ($content === 'Components') {
+				$colon = $this->phpcsFile->findNext(Tokens::$emptyTokens, ($ptr + 1), null, true);
+				$componentsFound = true;
+
+				if ($this->tokens[$colon]['code'] === \T_DOUBLE_COLON) {
+					// This is a static call to a Components class method.
+					$componentsMethodPtr = $this->phpcsFile->findNext(\T_STRING, ($colon + 1));
+
+					// Check if the call is to a render method.
+					if ($this->tokens[$componentsMethodPtr]['content'] === 'render') {
+						continue;
+					}
+				}
+			}
+
+			// Make the error message a little more informative for array access variables.
+			if ( \T_VARIABLE === $this->tokens[ $ptr ]['code'] ) {
+				$array_keys = $this->get_array_access_keys( $ptr );
+
+				if ( ! empty( $array_keys ) ) {
+					$content .= '[' . implode( '][', $array_keys ) . ']';
+				}
+			}
+
+			// Make error message nicer when Components helper is found.
+			if ($componentsFound) {
+				$methodName = $this->tokens[$componentsMethodPtr]['content'];
+				$content = "{$content}::{$methodName}";
+			}
+
+			$this->phpcsFile->addError(
+				"All output should be run through an escaping function (see the Security sections in the WordPress Developer Handbooks), found '%s'.",
+				$ptr,
+				'OutputNotEscaped',
+				array( $content )
+			);
+		}
+
+		return $end_of_statement;
+	}
+}

--- a/Eightshift/Sniffs/Shortcodes/DisallowDoShortcodeSniff.php
+++ b/Eightshift/Sniffs/Shortcodes/DisallowDoShortcodeSniff.php
@@ -3,11 +3,11 @@
 /**
  * Eightshift coding standards for WordPress
  *
- * @package Eightshift\Sniffs\Shortcodes
+ * @package EightshiftCS
  *
- * @author  Eightshift <info@infinum.co>
- * @license MIT https://github.com/infinum/coding-standards-wp/blob/master/LICENSE
- * @link    https://github.com/infinum/coding-standards-wp
+ * @author  Eightshift <team@eightshift.com>
+ * @license MIT https://github.com/infinum/eightshift-coding-standards/blob/master/LICENSE
+ * @link    https://github.com/infinum/eightshift-coding-standards
  *
  * @since 1.0.0 Removed the Tokens util. Modified the warning code
  * @since 0.4.2 Renamed the WPCS namespace - changed in v2.0.0 of WPCS

--- a/Eightshift/Sniffs/Shortcodes/DisallowDoShortcodeSniff.php
+++ b/Eightshift/Sniffs/Shortcodes/DisallowDoShortcodeSniff.php
@@ -6,7 +6,7 @@
  * @package EightshiftCS
  *
  * @author  Eightshift <team@eightshift.com>
- * @license MIT https://github.com/infinum/eightshift-coding-standards/blob/master/LICENSE
+ * @license https://opensource.org/licenses/MIT MIT
  * @link    https://github.com/infinum/eightshift-coding-standards
  *
  * @since 1.0.0 Removed the Tokens util. Modified the warning code

--- a/Eightshift/Tests/Security/CustomEscapeOutputUnitTest.inc
+++ b/Eightshift/Tests/Security/CustomEscapeOutputUnitTest.inc
@@ -1,0 +1,19 @@
+<?php
+
+echo Components::render('heading', [ // Ok.
+	'headingLevel' => 1,
+	'headingContent' => $mainTitle
+]);
+
+echo Components::classnames([ // Bad. Should be escaped.
+	'some-class',
+	'other-class-name'
+]);
+
+echo Components::ensureString($layoutBottom); // Bad, should be escaped.
+
+esc_html_e('Some string', 'project'); // Ok.
+echo __('Another string', 'project'); // Bad, esc_html__ should be used.
+echo $possibleEvilString; // Bad.
+echo wp_kses_post($possibleEvilString); // Ok.
+echo esc_html__('Translate me'); // Ok.

--- a/Eightshift/Tests/Security/CustomEscapeOutputUnitTest.php
+++ b/Eightshift/Tests/Security/CustomEscapeOutputUnitTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * Unit test class for DisallowDoShortcode sniff.
+ * Unit test class for CustomEscapeOutput sniff.
  *
  * @package EightshiftCS
  *
@@ -10,17 +10,16 @@
  * @link    https://github.com/infinum/eightshift-coding-standards
  */
 
-namespace EightshiftCS\Eightshift\Tests\Shortcodes;
+namespace EightshiftCS\Eightshift\Tests\Security;
 
 use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
 
 /**
- * Unit test class for the DisallowDoShortcode sniff.
+ * Unit test class for the CustomEscapeOutput sniff.
  *
- * @since 1.0.0 Added $testFile parameter.
- * @since 0.4.0
+ * @since 1.2.0
  */
-class DisallowDoShortcodeUnitTest extends AbstractSniffUnitTest
+class CustomEscapeOutputUnitTest extends AbstractSniffUnitTest
 {
 	/**
 	 * Returns the lines where errors should occur.
@@ -29,7 +28,12 @@ class DisallowDoShortcodeUnitTest extends AbstractSniffUnitTest
 	 */
 	public function getErrorList(): array
 	{
-		return [];
+		return [
+			8 => 1,
+			13 => 1,
+			16 => 1,
+			17 => 1
+		];
 	}
 
 	/**
@@ -39,13 +43,6 @@ class DisallowDoShortcodeUnitTest extends AbstractSniffUnitTest
 	 */
 	public function getWarningList(): array
 	{
-		return [
-			4 => 1,
-			5 => 1,
-			6 => 1,
-			7 => 1,
-			8 => 1,
-			9 => 1,
-		];
+		return [];
 	}
 }

--- a/Eightshift/ruleset.xml
+++ b/Eightshift/ruleset.xml
@@ -134,4 +134,11 @@
 	<rule ref="WordPress.WP">
 		<exclude name="WordPress.WP.TimezoneChange"/>
 	</rule>
+
+	<!-- Temporarily excluding the OutputNotEscaped sniff because of this issue:
+		 https://github.com/WordPress/WordPress-Coding-Standards/issues/1176#issuecomment-784045848
+		 Instead, a custom sniff has been added that will prevent flagging this as an error. -->
+	<rule ref="WordPress.Security.EscapeOutput">
+		<exclude name="WordPress.Security.EscapeOutput.OutputNotEscaped"/>
+	</rule>
 </ruleset>

--- a/Eightshift/ruleset.xml
+++ b/Eightshift/ruleset.xml
@@ -141,4 +141,5 @@
 	<rule ref="WordPress.Security.EscapeOutput">
 		<exclude name="WordPress.Security.EscapeOutput.OutputNotEscaped"/>
 	</rule>
+
 </ruleset>

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2020 Eightshift
+Copyright (c) 2021 Eightshift
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/Tests/RulesetCheck/RulesetTest7.inc
+++ b/Tests/RulesetCheck/RulesetTest7.inc
@@ -1,14 +1,13 @@
 <?php
 
 /**
- * View file for bulk email sending
+ * View file example
  *
  * @package Project
  */
 
 namespace Project;
 
-use Project\Callback\BulkEmailFormOptions;
 use ProjectVendor\EightshiftLibs\Helpers\Components;
 
 $manifest = Components::getManifest(__DIR__);
@@ -17,6 +16,15 @@ $componentName = $attributes['componentName'] ?? $manifest['componentName'];
 $mainTitle = Components::checkAttr('title', $attributes, $manifest, $componentName);
 $nonceField = Components::checkAttr('nonceField', $attributes, $manifest, $componentName);
 
+$classname = Components::classnames([
+	'some-class',
+	'other-class-name'
+]);
+
+echo Components::classnames([ // phpcs:ignore
+	'some-class',
+	'other-class-name'
+]);
 ?>
 
 <div class="wrap bulk-email js-bulk-mail-send">

--- a/Tests/RulesetCheck/RulesetTest7.inc
+++ b/Tests/RulesetCheck/RulesetTest7.inc
@@ -1,0 +1,41 @@
+<?php
+
+/**
+ * View file for bulk email sending
+ *
+ * @package Project
+ */
+
+namespace Project;
+
+use Project\Callback\BulkEmailFormOptions;
+use ProjectVendor\EightshiftLibs\Helpers\Components;
+
+$manifest = Components::getManifest(__DIR__);
+$componentName = $attributes['componentName'] ?? $manifest['componentName'];
+
+$title = Components::checkAttr('title', $attributes, $manifest, $componentName);
+$nonceField = Components::checkAttr('nonceField', $attributes, $manifest, $componentName);
+
+?>
+
+<div class="wrap bulk-email js-bulk-mail-send">
+	<div class="bulk-email__wrapper">
+		<?php
+		echo Components::render('heading', [
+			'headingLevel' => 1,
+			'headingContent' => $title
+		]),
+		Components::render('paragraph', [
+			'paragraphContent' => \esc_html__(
+				'Use the form below to send the bulk emails to conference attendees.',
+				'project'
+			),
+			'componentClass' => 'description'
+		]); ?>
+	</div>
+	<div class="bulk-email__notice js-form-notice"></div>
+</div>
+
+<?php
+echo $nonceField; // phpcs:ignore

--- a/Tests/RulesetCheck/RulesetTest7.inc
+++ b/Tests/RulesetCheck/RulesetTest7.inc
@@ -14,7 +14,7 @@ use ProjectVendor\EightshiftLibs\Helpers\Components;
 $manifest = Components::getManifest(__DIR__);
 $componentName = $attributes['componentName'] ?? $manifest['componentName'];
 
-$title = Components::checkAttr('title', $attributes, $manifest, $componentName);
+$mainTitle = Components::checkAttr('title', $attributes, $manifest, $componentName);
 $nonceField = Components::checkAttr('nonceField', $attributes, $manifest, $componentName);
 
 ?>
@@ -24,7 +24,7 @@ $nonceField = Components::checkAttr('nonceField', $attributes, $manifest, $compo
 		<?php
 		echo Components::render('heading', [
 			'headingLevel' => 1,
-			'headingContent' => $title
+			'headingContent' => $mainTitle
 		]),
 		Components::render('paragraph', [
 			'paragraphContent' => \esc_html__(

--- a/composer.json
+++ b/composer.json
@@ -52,7 +52,7 @@
 		"standards:check": "@php ./vendor/squizlabs/php_codesniffer/bin/phpcs",
 		"standards:fix": "@php ./vendor/squizlabs/php_codesniffer/bin/phpcbf",
 		"tests:run": "@php ./vendor/phpunit/phpunit/phpunit --filter Eightshift ./vendor/squizlabs/php_codesniffer/tests/AllTests.php",
-		"tests:checkcs": "@php ./vendor/squizlabs/php_codesniffer/bin/phpcs --standard=./Eightshift ./Tests/",
+		"tests:checkcs": "@php ./vendor/squizlabs/php_codesniffer/bin/phpcs -ps ./Tests/RulesetCheck/ --standard=Eightshift",
 		"check:complete": "@php ./vendor/phpcsstandards/phpcsdevtools/bin/phpcs-check-feature-completeness -q ./Eightshift",
 		"check:complete-strict": "@php ./vendor/phpcsstandards/phpcsdevtools/bin/phpcs-check-feature-completeness ./Eightshift"
 	},


### PR DESCRIPTION
This PR will close the #39 issue.

The functionality of the escaping sniff is the same, I just added a part that will handle the `Components::render` method.

Once this get's fixed upstream (that is static method calls gets added as valid auto escaped functions), we can remove this addition.

Edit: for clarity's sake, I didn't write the entire sniff 😂   I just added the parts on lines 316-330 and 342-345 of the sniff.