### PR TITLE
Phpcbf bugfix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,13 @@ The semantic versioning started from version 0.2.1.
 
 _No documentation available about unreleased changes yet._
 
+## [1.4.1](https://github.com/infinum/eightshift-coding-standards/compare/1.4.0...1.4.1) - 2022-03-10
+
+### Fixed
+- Fixed `Eightshift.Security.ComponentsEscape` sniff
+  - There was a case where the next string token caused issue because there was no guard clause 
+    to check if the string is actually a Components class or not.
+
 ## [1.4.0](https://github.com/infinum/eightshift-coding-standards/compare/1.3.0...1.4.0) - 2022-03-09
 
 ### Added

--- a/Eightshift/Sniffs/Security/ComponentsEscapeSniff.php
+++ b/Eightshift/Sniffs/Security/ComponentsEscapeSniff.php
@@ -69,6 +69,14 @@ class ComponentsEscapeSniff extends EscapeOutputSniff
 				return parent::process_token($stackPtr);
 			}
 
+			// Check the next string token content.
+			if ($importExists) {
+				$fullyQualifiedImport = $importData['importName'];
+				if (\strpos($fullyQualifiedImport, $tokens[$elementPtr]['content']) === false) {
+					return parent::process_token($stackPtr);
+				}
+			}
+
 			// Check for Components string token.
 			$componentsClassNamePtr = $phpcsFile->findNext(\T_STRING, ($stackPtr + 1), null, false, 'Components', false);
 

--- a/Eightshift/Tests/Security/ComponentsEscapeUnitTest.4.inc
+++ b/Eightshift/Tests/Security/ComponentsEscapeUnitTest.4.inc
@@ -1,0 +1,129 @@
+<?php
+
+/**
+ * Template for the Wrapping Advanced block.
+ *
+ * @package EightshiftBoilerplate
+ */
+
+use EightshiftBoilerplateVendor\EightshiftLibs\Helpers\Components;
+
+$manifest = Components::getManifest(__DIR__);
+
+// Used to add or remove wrapper.
+$wrapperUse = Components::checkAttr('wrapperUse', $attributes, $manifest);
+$wrapperUseSimple = Components::checkAttr('wrapperUseSimple', $attributes, $manifest);
+$wrapperDisable = Components::checkAttr('wrapperDisable', $attributes, $manifest);
+$wrapperParentClass = Components::checkAttr('wrapperParentClass', $attributes, $manifest);
+$className = Components::checkAttr('className', $attributes, $manifest);
+
+$wrapperParentClassItemClass = Components::selector($wrapperParentClass, $wrapperParentClass, 'item');
+$wrapperParentClassItemInnerClass = Components::selector($wrapperParentClass, $wrapperParentClass, 'item-inner');
+
+if (!$wrapperUse || $wrapperDisable) {
+	if ($wrapperParentClass) {
+		?>
+			<div class="<?php echo esc_attr($wrapperParentClassItemClass); ?>">
+				<div class="<?php echo esc_attr($wrapperParentClassItemInnerClass); ?>">
+		<?php
+	}
+
+	$this->renderWrapperView(
+		$templatePath,
+		$attributes,
+		$innerBlockContent
+	);
+
+	if ($wrapperParentClass) {
+		?>
+			</div>
+		</div>
+		<?php
+	}
+
+	return;
+}
+
+$wrapperId = Components::checkAttr('wrapperId', $attributes, $manifest);
+$wrapperAnchorId = Components::checkAttr('wrapperAnchorId', $attributes, $manifest);
+$wrapperBackgroundColor = Components::checkAttr('wrapperBackgroundColor', $attributes, $manifest);
+
+$wrapperHide = Components::checkAttrResponsive('wrapperHide', $attributes, $manifest);
+$wrapperSpacingTop = Components::checkAttrResponsive('wrapperSpacingTop', $attributes, $manifest);
+$wrapperSpacingBottom = Components::checkAttrResponsive('wrapperSpacingBottom', $attributes, $manifest);
+$wrapperSpacingTopIn = Components::checkAttrResponsive('wrapperSpacingTopIn', $attributes, $manifest);
+$wrapperSpacingBottomIn = Components::checkAttrResponsive('wrapperSpacingBottomIn', $attributes, $manifest);
+$wrapperDividerTop = Components::checkAttrResponsive('wrapperDividerTop', $attributes, $manifest);
+$wrapperDividerBottom = Components::checkAttrResponsive('wrapperDividerBottom', $attributes, $manifest);
+$wrapperContainerWidth = Components::checkAttrResponsive('wrapperContainerWidth', $attributes, $manifest);
+$wrapperGutter = Components::checkAttrResponsive('wrapperGutter', $attributes, $manifest);
+$wrapperWidth = Components::checkAttrResponsive('wrapperWidth', $attributes, $manifest);
+$wrapperOffset = Components::checkAttrResponsive('wrapperOffset', $attributes, $manifest);
+
+$componentClass = 'wrapper';
+
+$wrapperClass = Components::classnames([
+	$componentClass,
+	Components::selector($componentClass, $componentClass, 'bg-color', $wrapperBackgroundColor), // @phpstan-ignore-line
+	Components::responsiveSelectors($wrapperSpacingTop, 'spacing-top', $componentClass),
+	Components::responsiveSelectors($wrapperSpacingBottom, 'spacing-bottom', $componentClass),
+	Components::responsiveSelectors($wrapperSpacingTopIn, 'spacing-top-in', $componentClass),
+	Components::responsiveSelectors($wrapperSpacingBottomIn, 'spacing-bottom-in', $componentClass),
+	Components::responsiveSelectors($wrapperDividerTop, 'divider-top', $componentClass, false),
+	Components::responsiveSelectors($wrapperDividerBottom, 'divider-bottom', $componentClass, false),
+	Components::responsiveSelectors($wrapperHide, 'hide', $componentClass, false),
+	$className,
+]);
+
+$wrapperContainerClass = Components::classnames([
+	Components::selector($componentClass, $componentClass, 'container'), // @phpstan-ignore-line
+	Components::responsiveSelectors($wrapperContainerWidth, 'container-width', $componentClass),
+	Components::responsiveSelectors($wrapperGutter, 'gutter', $componentClass),
+]);
+
+$wrapperInnerClass = Components::classnames([
+	Components::selector($componentClass, $componentClass, 'inner'), // @phpstan-ignore-line
+	Components::responsiveSelectors($wrapperWidth, 'width', $componentClass),
+	Components::responsiveSelectors($wrapperOffset, 'offset', $componentClass),
+]);
+
+$wrapperMainAnchorClass = Components::selector($componentClass, $componentClass, 'anchor'); // @phpstan-ignore-line
+
+$idOutput = '';
+
+if ($wrapperId) {
+	$escapedId = esc_attr($wrapperId);
+	$idOutput = "id='{$escapedId}'";
+}
+
+?>
+<div
+	class="<?php echo esc_attr($wrapperClass); ?>"
+	<?php echo $idOutput; // Bad ?>
+>
+	<?php if ($wrapperAnchorId) { ?>
+		<div class="<?php echo esc_attr($wrapperMainAnchorClass); ?>" id="<?php echo esc_attr($wrapperAnchorId); ?>"></div>
+	<?php } ?>
+
+	<?php if ($wrapperUseSimple) { ?>
+		<?php
+		$this->renderWrapperView(
+			$templatePath,
+			$attributes,
+			$innerBlockContent
+		);
+		?>
+	<?php } else { ?>
+		<div class="<?php echo esc_attr($wrapperContainerClass); ?>">
+			<div class="<?php echo esc_attr($wrapperInnerClass); ?>">
+				<?php
+				$this->renderWrapperView(
+					$templatePath,
+					$attributes,
+					$innerBlockContent
+				);
+				?>
+			</div>
+		</div>
+	<?php } ?>
+</div>

--- a/Eightshift/Tests/Security/ComponentsEscapeUnitTest.php
+++ b/Eightshift/Tests/Security/ComponentsEscapeUnitTest.php
@@ -50,6 +50,10 @@ class ComponentsEscapeUnitTest extends AbstractSniffUnitTest
 					19 => 1,
 					24 => 1,
 				];
+			case 'ComponentsEscapeUnitTest.4.inc':
+				return [
+					102 => 1,
+				];
 			default:
 				return [];
 		}


### PR DESCRIPTION
### Fixed
- Fixed `Eightshift.Security.ComponentsEscape` sniff
  - There was a case where the next string token caused issue because there was no guard clause 
    to check if the string is actually a Components class or not.