### PR TITLE
Add new parameter to the function comment sniff

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,11 +10,17 @@ The semantic versioning started from version 0.2.1.
 
 _No documentation available about unreleased changes yet._
 
+## [1.6.0](https://github.com/infinum/eightshift-coding-standards/compare/1.5.1...1.6.0) - 2022-07-05
+
+### Changed
+- Add a parameter `$allowedExtendedClasses` in the FunctionComment sniff
+  - This way we can add a list of specific extending CLI classes which won't trigger
+    phpcs error on the __invoke() method.
+
 ## [1.5.1](https://github.com/infinum/eightshift-coding-standards/compare/1.5.0...1.5.1) - 2022-05-10
 
 ### Fixed
-- CI/CD check fixes 
-
+- CI/CD check fixes
 
 ## [1.5.0](https://github.com/infinum/eightshift-coding-standards/compare/1.4.2...1.5.0) - 2022-03-16
 

--- a/Eightshift/Sniffs/Commenting/FunctionCommentSniff.php
+++ b/Eightshift/Sniffs/Commenting/FunctionCommentSniff.php
@@ -23,11 +23,20 @@ use PHPCSUtils\Utils\ObjectDeclarations;
  * Override the Squiz.Commenting.FunctionComment sniff
  *
  * This sniff will ignore the __invoke method in all the classes
- * that are extending the AbstractCli, which is used in the
- * eightshift-libs library to generate WP-CLI commands.
+ * that are extending the AbstractCli (or any of the class in the $allowedExtendedClasses list),
+ * which is used in the eightshift-libs library to generate WP-CLI commands.
  */
 class FunctionCommentSniff extends SquizFunctionComment
 {
+	/**
+	 * List of allowed classes that can be extended.
+	 *
+	 * @var string[]
+	 */
+	public $allowedExtendedClasses = [
+		'AbstractCli',
+	];
+
 	/**
 	 * Processes this test, when one of its tokens is encountered.
 	 *
@@ -43,8 +52,8 @@ class FunctionCommentSniff extends SquizFunctionComment
 	public function process(File $phpcsFile, $stackPtr)
 	{
 		// If the function is the called __invoke, and is inside the class
-		// that extends the AbstractCli class, we need to bow out. In all other cases
-		// we want to run the sniff.
+		// that extends the AbstractCli class (or any of the class in the $allowedExtendedClasses list),
+		// we need to bow out. In all other cases we want to run the sniff.
 		$functionName = $phpcsFile->getDeclarationName($stackPtr);
 
 		if ($functionName !== '__invoke') {
@@ -62,7 +71,7 @@ class FunctionCommentSniff extends SquizFunctionComment
 
 		$extendedClassName = ObjectDeclarations::findExtendedClassName($phpcsFile, $classPtr);
 
-		if ($extendedClassName !== 'AbstractCli') {
+		if (!\in_array($extendedClassName, $this->allowedExtendedClasses, true)) {
 			return parent::process($phpcsFile, $stackPtr);
 		}
 	}

--- a/Eightshift/Tests/Commenting/FunctionCommentUnitTest.inc
+++ b/Eightshift/Tests/Commenting/FunctionCommentUnitTest.inc
@@ -88,3 +88,44 @@ function __invoke() {
 function __invoke(string $name) {
 	// This code complies with the standards.
 }
+
+// phpcs:set Eightshift.Commenting.FunctionComment allowedExtendedClasses[] SomeOtherCliClass, AbstractCli
+class RegularClass extends SomeOtherCliClass
+{
+	public function __invoke(array $args, array $assocArgs)
+	{
+		// This method should not throw an error because we added
+        // the extending class to the list of allowed classes.
+	}
+
+	/**
+	 * @param array $args      Arguments.
+	 * @param array $assocArgs Associated arguments.
+	 *
+	 * @return void
+	 */
+	public function __invoke(array $args, array $assocArgs)
+	{
+		// This code complies with the standards.
+	}
+}
+
+// phpcs:set Eightshift.Commenting.FunctionComment allowedExtendedClasses[] AbstractCli
+class RegularClass extends SomeOtherCliClass
+{
+	public function __invoke(array $args, array $assocArgs)
+	{
+		// This method should throw an error because it doesn't extend AbstractCli class.
+	}
+
+	/**
+	 * @param array $args      Arguments.
+	 * @param array $assocArgs Associated arguments.
+	 *
+	 * @return void
+	 */
+	public function __invoke(array $args, array $assocArgs)
+	{
+		// This code complies with the standards.
+	}
+}

--- a/Eightshift/Tests/Commenting/FunctionCommentUnitTest.php
+++ b/Eightshift/Tests/Commenting/FunctionCommentUnitTest.php
@@ -36,6 +36,7 @@ class FunctionCommentUnitTest extends AbstractSniffUnitTest
 			43 => 1,
 			62 => 1,
 			79 => 1,
+			116 => 1,
 		];
 	}
 


### PR DESCRIPTION
## Description
Update the FunctionComment sniff to allow for custom extending CLI classes which should ignore the `__invoke()` method.

## Checklist:
- [x] My code is tested.
- [x] My code follows the code style set by the project.
- [x] I've included sniff documentation.
