### PR TITLE
Update dependencies 

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php: ['7.2', '7.3', '7.4']
+        php: ['7.4', '8.0', '8.1']
 
     name: "Lint: PHP ${{ matrix.php }}"
 

--- a/.github/workflows/ruleset-checks-sniffs.yml
+++ b/.github/workflows/ruleset-checks-sniffs.yml
@@ -70,13 +70,17 @@ jobs:
       - name: Show PHPCS results in PR
         run: cs2pr ./phpcs-report.xml --graceful-warnings
 
-      # Validate the XML files.
+      # Validate the Ruleset XML files.
       # @link http://xmlsoft.org/xmllint.html
       - name: Validate the WordPress rulesets
         run: xmllint --noout --schema vendor/squizlabs/php_codesniffer/phpcs.xsd ./*/ruleset.xml
 
       - name: Validate the sample ruleset
         run: xmllint --noout --schema vendor/squizlabs/php_codesniffer/phpcs.xsd ./phpcs.xml.dist.sample
+
+      # Validate the Documentation XML files.
+      - name: Validate documentation against schema
+        run: xmllint --noout --schema vendor/phpcsstandards/phpcsdevtools/DocsXsd/phpcsdocs.xsd ./Eightshift/Docs/*/*Standard.xml
 
       - name: Check the code-style consistency of the xml files
         run: |

--- a/.github/workflows/ruleset-checks-sniffs.yml
+++ b/.github/workflows/ruleset-checks-sniffs.yml
@@ -114,7 +114,7 @@ jobs:
     strategy:
       matrix:
         php: [ '7.4' ]
-        phpcs_version: [ 'dev-master', '3.6.0' ]
+        phpcs_version: [ 'dev-master', '3.7.0' ]
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,28 +24,16 @@ jobs:
       fail-fast: false
       matrix:
         # Builds against PHP 7.2, 7.4 are specified separately in the "include" section below.
-        php: [ '7.3' ]
-        phpcs_branch: [ '3.6.0', 'dev-master' ]
+        php: [ '7.4', '8.0', '8.1' ]
+        phpcs_branch: [ '3.7.0', 'dev-master' ]
         wpcs_branch: [ '2.2.0', 'dev-master' ]
         allowed_failure: [ false ]
         exclude:
           # Only run low WPCS in combination with low PHPCS and high WPCS with high PHPCS.
           - phpcs_branch: 'dev-master'
             wpcs_branch: '2.2.0'
-          - phpcs_branch: '3.6.0'
+          - phpcs_branch: '3.7.0'
             wpcs_branch: 'dev-master'
-        include:
-          # Complete the matrix.
-          # Compliment the matrix with some additional builds.
-          # Separate test builds for PHP 7.2 with reversed PHPCS vs WPCS branches.
-          - php: '7.2'
-            phpcs_branch: 'dev-master'
-            wpcs_branch: '2.2.0'
-            allowed_failure: false
-          - php: '7.2'
-            phpcs_branch: '3.6.0'
-            wpcs_branch: 'dev-master'
-            allowed_failure: false
 
           # Experimental build to see how much breaks against WPCS 3.0.
           - php: '7.4'

--- a/Eightshift/Docs/Commenting/FunctionCommentStandard.xml
+++ b/Eightshift/Docs/Commenting/FunctionCommentStandard.xml
@@ -1,4 +1,8 @@
-<documentation title="Function comment">
+<?xml version="1.0"?>
+<documentation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="https://phpcsstandards.github.io/PHPCSDevTools/phpcsdocs.xsd"
+    title="Function comment"
+    >
     <standard>
     <![CDATA[
       Modification of the SquizFunctionComment sniff where we want remove docblock for the  __invoke method in all classes extending AbstractCli class.
@@ -34,7 +38,24 @@ class RegularClass extends NotAbstractCli
 }
         ]]>
         </code>
-        <code title="Invalid: Missing a docblock on a class which is not extending AbstractCli class">
+    </code_comparison>
+    <code_comparison>
+        <code title="Valid: Having a docblock on __invoke in a class which is not extending AbstractCli class">
+        <![CDATA[
+class NotExtendingClass
+{
+    /**
+     * @param array $args List of arguments.
+     *
+     * @return void
+     */
+    public function __invoke(array $args)
+    {
+    }
+}
+        ]]>
+        </code>
+        <code title="Invalid: Missing a docblock on __invoke in a class which is not extending AbstractCli class">
         <![CDATA[
 class NotExtendingClass
 {

--- a/Eightshift/Docs/Security/ComponentsEscapeStandard.xml
+++ b/Eightshift/Docs/Security/ComponentsEscapeStandard.xml
@@ -1,4 +1,8 @@
-<documentation title="Components escape">
+<?xml version="1.0"?>
+<documentation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="https://phpcsstandards.github.io/PHPCSDevTools/phpcsdocs.xsd"
+    title="Components escape"
+    >
     <standard>
     <![CDATA[
       Modification of the EscapeOutput sniff where we want to silence escape errors on library specific safe static methods.
@@ -27,6 +31,8 @@ echo ProjectVendor\EightshiftLibs\Helpers\Components::outputCssVariables(
 );
         ]]>
         </code>
+    </code_comparison>
+    <code_comparison>
         <code title="Invalid: Using globally namespaced methods">
         <![CDATA[
 echo \Components::outputCssVariables($attributes, $manifest, $unique, $globalManifest);

--- a/Eightshift/Docs/Shortcodes/DisallowDoShortcodeStandard.xml
+++ b/Eightshift/Docs/Shortcodes/DisallowDoShortcodeStandard.xml
@@ -1,4 +1,8 @@
-<documentation title="Disallow Do Shortcode">
+<?xml version="1.0"?>
+<documentation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="https://phpcsstandards.github.io/PHPCSDevTools/phpcsdocs.xsd"
+    title="Disallow Do Shortcode"
+    >
     <standard>
     <![CDATA[
       The do_shortcode() WordPress function should not be used inside php source files.

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
 		}
 	],
 	"require": {
-		"php": "^7.2",
+		"php": "^7.4",
 		"squizlabs/php_codesniffer": "^3.7.0",
 		"phpcompatibility/phpcompatibility-wp": "^2.1.1",
 		"wp-coding-standards/wpcs": "^2.3.0",

--- a/composer.json
+++ b/composer.json
@@ -6,6 +6,7 @@
 		"phpcs",
 		"standards",
 		"WordPress",
+		"static analysis",
 		"Eightshift"
 	],
 	"homepage": "https://github.com/infinum/eightshift-coding-standards",

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
 	],
 	"require": {
 		"php": "^7.2",
-		"squizlabs/php_codesniffer": "^3.6.0",
+		"squizlabs/php_codesniffer": "^3.7.0",
 		"phpcompatibility/phpcompatibility-wp": "^2.1.1",
 		"wp-coding-standards/wpcs": "^2.3.0",
 		"phpcsstandards/phpcsutils": "^1.0",

--- a/composer.json
+++ b/composer.json
@@ -28,11 +28,11 @@
 		"wp-coding-standards/wpcs": "^2.3.0",
 		"phpcsstandards/phpcsutils": "^1.0",
 		"phpcsstandards/phpcsextra": "^1.0",
-		"slevomat/coding-standard": "^7.0"
+		"slevomat/coding-standard": "^8.0"
 	},
 	"require-dev": {
 		"phpunit/phpunit": "^4.0 || ^5.0 || ^6.0 || ^7.0",
-		"phpcsstandards/phpcsdevtools": "^1.0",
+		"phpcsstandards/phpcsdevtools": "^1.2.0",
 		"php-parallel-lint/php-parallel-lint": "^1.3.2",
 		"php-parallel-lint/php-console-highlighter": "^1.0.0",
 		"roave/security-advisories": "dev-master"


### PR DESCRIPTION
PHPCSDevTools 1.2.0 introduces an XSD for the XML docs which can accompany sniffs to ensure the documentation validity. 

With that in mind, I went and updated the packages and added a test against additional PHP versions.

### Changed

- PHPCSDevTools was updated to version 1.2.0.
- A new check was added in GH Actions to check against the new XSD for all sniff XML Docs files.
    Ref: https://github.com/PHPCSStandards/PHPCSDevTools/releases/tag/1.2.0
- Includes adding the <?xml..?> header if it didn't exist in the file.
- Raise the minimum PHP version to 7.4.
- Add the tests for PHP 8+

To do:
- Update tests to include PHP 8+ syntax.