### PR TITLE
Changes for Components helper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ The semantic versioning started from version 0.2.1.
 
 _No documentation available about unreleased changes yet._
 
-## [2.1.0](https://github.com/infinum/eightshift-coding-standards/compare/2.0.0...2.1.0)
+## [3.0.0](https://github.com/infinum/eightshift-coding-standards/compare/2.0.0...3.0.0)
 
 ### Changed
 - Components helpers in the new eightshift-libs@8.0.0 is deprecated and removed. Instead `Helpers` is used. The `Eightshift.Security.ComponentsEscape` sniff is updated and renamed to `Eightshift.Security.HelpersEscape` to reflect this change.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ The semantic versioning started from version 0.2.1.
 
 _No documentation available about unreleased changes yet._
 
+## [2.1.0](https://github.com/infinum/eightshift-coding-standards/compare/2.0.0...2.1.0)
+
+### Changed
+- Components helpers in the new eightshift-libs@8.0.0 is deprecated and removed. Instead `Helpers` is used. The `Eightshift.Security.ComponentsEscape` sniff is updated and renamed to `Eightshift.Security.HelpersEscape` to reflect this change.
+
 ## [2.0.0](https://github.com/infinum/eightshift-coding-standards/compare/1.6.0...2.0.0) - 2023-09-XX
 
 ### Added

--- a/Eightshift/Docs/Security/ComponentsEscapeStandard.xml
+++ b/Eightshift/Docs/Security/ComponentsEscapeStandard.xml
@@ -1,20 +1,20 @@
 <?xml version="1.0"?>
 <documentation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:noNamespaceSchemaLocation="https://phpcsstandards.github.io/PHPCSDevTools/phpcsdocs.xsd"
-    title="Components escape">
+    title="Helpers escape">
     <standard>
     <![CDATA[
       Modification of the EscapeOutput sniff where we want to silence escape errors on library specific safe static methods.
     ]]>
     </standard>
     <code_comparison>
-        <code title="Valid: Calling Components::render if the Components class comes from EightshiftLibs">
+        <code title="Valid: Calling Helpers::render if the Helpers class comes from EightshiftLibs">
         <![CDATA[
-use ProjectVendor\EightshiftLibs\Helpers\Components;
+use ProjectVendor\EightshiftLibs\Helpers\Helpers;
 
-echo Components::render(
+echo Helpers::render(
     'accordion',
-    Components::props('accordion', $attributes, [
+    Helpers::props('accordion', $attributes, [
         'accordionContent' => $innerBlockContent
     ])
 );
@@ -22,16 +22,16 @@ echo Components::render(
         </code>
         <code title="Invalid: Using globally namespaced methods">
         <![CDATA[
-echo \Components::outputCssVariables($attributes, $manifest, $unique, $globalManifest);
+echo \Helpers::outputCssVariables($attributes, $manifest, $unique, $globalManifest);
         ]]>
         </code>
     </code_comparison>
     <code_comparison>
         <code title="Valid: Referencing fully qualified class name">
         <![CDATA[
-echo ProjectVendor\EightshiftLibs\Helpers\Components::outputCssVariables(
+echo ProjectVendor\EightshiftLibs\Helpers\Helpers::outputCssVariables(
     'accordion',
-    Components::props('accordion', $attributes, [
+    Helpers::props('accordion', $attributes, [
         'accordionContent' => $innerBlockContent
     ])
 );
@@ -39,7 +39,7 @@ echo ProjectVendor\EightshiftLibs\Helpers\Components::outputCssVariables(
         </code>
         <code title="Invalid: Calling a non safe method">
         <![CDATA[
-echo Components::props('accordion', $attributes, [
+echo Helpers::props('accordion', $attributes, [
     'accordionContent' => $innerBlockContent
 ]);
         ]]>

--- a/Eightshift/Sniffs/Security/HelpersEscapeSniff.php
+++ b/Eightshift/Sniffs/Security/HelpersEscapeSniff.php
@@ -21,22 +21,22 @@ use WordPressCS\WordPress\Sniffs\Security\EscapeOutputSniff;
  * Override the WordPress.Security.EscapeOutput sniff
  *
  * This sniff will ignore escaping errors whenever it finds the
- * EightshiftLibs\Helpers\Components::$allowedMethods, where the $allowedMethods are by default `render` and `outputCssVariables`, but can be extended in the ruleset.
+ * EightshiftLibs\Helpers\Helpers::$allowedMethods, where the $allowedMethods are by default `render` and `outputCssVariables`, but can be extended in the ruleset.
  *
  * $allowedMethods are considered safe.
  *
  * @since 2.0.0 Add list of allowed static methods that shouldn't trigger the sniff error.
  * @since 1.4.0
  */
-class ComponentsEscapeSniff extends EscapeOutputSniff
+class HelpersEscapeSniff extends EscapeOutputSniff
 {
 	/**
-	 * A fully qualified class name for Components class override.
+	 * A fully qualified class name for Helpers class override.
 	 *
 	 * You should put the fully qualified class name of the class you used
 	 * to override the EightshiftLibs\Helpers\Component class.
 	 *
-	 * For Example: namespace\\SomeSubNamespace\\MyComponents.
+	 * For Example: namespace\\SomeSubNamespace\\MyHelpers.
 	 *
 	 * @since 1.4.0
 	 *
@@ -98,7 +98,7 @@ class ComponentsEscapeSniff extends EscapeOutputSniff
 			// Check the next token after echo.
 			$elementPtr = $phpcsFile->findNext(Tokens::$emptyTokens, ($stackPtr + 1), null, true);
 
-			// If it's not the string token, move on, we're only interested in Components string.
+			// If it's not the string token, move on, we're only interested in Helpers string.
 			if ($tokens[$elementPtr]['code'] !== \T_STRING) {
 				return parent::process_token($stackPtr);
 			}
@@ -111,23 +111,23 @@ class ComponentsEscapeSniff extends EscapeOutputSniff
 				}
 			}
 
-			// Check for Components string token.
-			$componentsClassNamePtr = $phpcsFile->findNext(\T_STRING, ($stackPtr + 1), null, false, 'Components');
+			// Check for Helpers string token.
+			$helpersClassNamePtr = $phpcsFile->findNext(\T_STRING, ($stackPtr + 1), null, false, 'Helpers');
 
-			if (!$componentsClassNamePtr) {
-				// If there is no Components down the line, just run the regular sniff.
+			if (!$helpersClassNamePtr) {
+				// If there is no Helpers down the line, just run the regular sniff.
 				return parent::process_token($stackPtr);
 			}
 
 			// Check if the next token is double colon. We are interested in static methods.
-			if ($tokens[$componentsClassNamePtr + 1]['code'] !== \T_DOUBLE_COLON) {
-				$echoPtr = $phpcsFile->findPrevious(\T_ECHO, ($componentsClassNamePtr - 1), null, false, null, true);
+			if ($tokens[$helpersClassNamePtr + 1]['code'] !== \T_DOUBLE_COLON) {
+				$echoPtr = $phpcsFile->findPrevious(\T_ECHO, ($helpersClassNamePtr - 1), null, false, null, true);
 
 				return parent::process_token($echoPtr);
 			}
 
 			// If it is, check, if the class is imported or fully qualified.
-			$nameEnd = $phpcsFile->findPrevious(\T_STRING, ($componentsClassNamePtr + 1));
+			$nameEnd = $phpcsFile->findPrevious(\T_STRING, ($helpersClassNamePtr + 1));
 			$nameStart = ($phpcsFile->findPrevious(
 				[\T_STRING, \T_NS_SEPARATOR, \T_NAMESPACE],
 				($nameEnd - 1),
@@ -140,18 +140,18 @@ class ComponentsEscapeSniff extends EscapeOutputSniff
 			$className = GetTokensAsString::normal($phpcsFile, $nameStart, $nameEnd);
 
 			if ($importExists) {
-				// Fully qualified import, i.e. EightshiftLibs\Helpers\Components.
+				// Fully qualified import, i.e. EightshiftLibs\Helpers\Helpers.
 				if ($importData['fullImportExists']) {
-					// Components name is ok, \Components is not ok, \Anything\Components is not ok FQCN is ok.
+					// Helpers name is ok, \Helpers is not ok, \Anything\Helpers is not ok FQCN is ok.
 					if (
-						$className === 'Components'
-						|| \strpos($className, 'EightshiftLibs\\Helpers\\Components') !== false
+						$className === 'Helpers'
+						|| \strpos($className, 'EightshiftLibs\\Helpers\\Helpers') !== false
 						|| (! empty($this->overriddenClass) && \strpos($className, $this->overriddenClass) !== false)
 					) {
 						// Check the static method name.
 						$methodNamePtr = $phpcsFile->findNext(
 							\T_STRING,
-							($componentsClassNamePtr + 1),
+							($helpersClassNamePtr + 1),
 							null,
 							false,
 							null,
@@ -162,13 +162,13 @@ class ComponentsEscapeSniff extends EscapeOutputSniff
 							return; // Skip sniffing allowed methods.
 						} else {
 							// Not allowed method, continue as usual.
-							$echoPtr = $this->getEchoToken($componentsClassNamePtr);
+							$echoPtr = $this->getEchoToken($helpersClassNamePtr);
 
 							return parent::process_token($echoPtr);
 						}
 					} else {
 						// Some other class we don't care about.
-						$echoPtr = $this->getEchoToken($componentsClassNamePtr);
+						$echoPtr = $this->getEchoToken($helpersClassNamePtr);
 
 						return parent::process_token($echoPtr);
 					}
@@ -184,7 +184,7 @@ class ComponentsEscapeSniff extends EscapeOutputSniff
 						// Correctly used class name.
 						$methodNamePtr = $phpcsFile->findNext(
 							\T_STRING,
-							($componentsClassNamePtr + 1),
+							($helpersClassNamePtr + 1),
 							null,
 							false,
 							null,
@@ -195,13 +195,13 @@ class ComponentsEscapeSniff extends EscapeOutputSniff
 							return; // Skip sniffing allowed methods.
 						} else {
 							// Not allowed method, continue as usual.
-							$echoPtr = $this->getEchoToken($componentsClassNamePtr);
+							$echoPtr = $this->getEchoToken($helpersClassNamePtr);
 
 							return parent::process_token($echoPtr);
 						}
 					} else {
 						// Wrongly imported, or class that is not related to the libs.
-						$echoPtr = $this->getEchoToken($componentsClassNamePtr);
+						$echoPtr = $this->getEchoToken($helpersClassNamePtr);
 
 						return parent::process_token($echoPtr);
 					}
@@ -209,12 +209,12 @@ class ComponentsEscapeSniff extends EscapeOutputSniff
 			} else {
 				// Check if the class name is fully qualified and contains the helper part.
 				if (
-					\strpos($className, 'EightshiftLibs\\Helpers\\Components') !== false
+					\strpos($className, 'EightshiftLibs\\Helpers\\Helpers') !== false
 					|| (! empty($this->overriddenClass) && \strpos($className, $this->overriddenClass) !== false)
 				) {
 					$methodNamePtr = $phpcsFile->findNext(
 						\T_STRING,
-						($componentsClassNamePtr + 1),
+						($helpersClassNamePtr + 1),
 						null,
 						false,
 						null,
@@ -225,12 +225,12 @@ class ComponentsEscapeSniff extends EscapeOutputSniff
 						return; // Skip sniffing allowed methods.
 					} else {
 						// Not allowed method, continue as usual.
-						$echoPtr = $this->getEchoToken($componentsClassNamePtr);
+						$echoPtr = $this->getEchoToken($helpersClassNamePtr);
 
 						return parent::process_token($echoPtr);
 					}
 				} else {
-					$echoPtr = $this->getEchoToken($componentsClassNamePtr);
+					$echoPtr = $this->getEchoToken($helpersClassNamePtr);
 
 					return parent::process_token($echoPtr);
 				}
@@ -271,7 +271,7 @@ class ComponentsEscapeSniff extends EscapeOutputSniff
 
 						// Check for fully qualified import.
 						if (
-							\strpos($fullyQualifiedClassNameImport, 'EightshiftLibs\\Helpers\\Components') !== false
+							\strpos($fullyQualifiedClassNameImport, 'EightshiftLibs\\Helpers\\Helpers') !== false
 							|| (! empty($overriddenClass) && \strpos($fullyQualifiedClassNameImport, $overriddenClass) !== false) // phpcs:ignore Generic.Files.LineLength.TooLong
 						) {
 							$importData['fullImportExists'] = true;

--- a/Eightshift/Tests/Security/ComponentsEscapeUnitTest.1.inc
+++ b/Eightshift/Tests/Security/ComponentsEscapeUnitTest.1.inc
@@ -1,23 +1,23 @@
 <?php
 
-use ProjectVendor\EightshiftLibs\Helpers\Components;
+use ProjectVendor\EightshiftLibs\Helpers\Helpers;
 
-echo Components::render( // OK (imported method)
+echo Helpers::render( // OK (imported method)
 	'accordion',
-	Components::props('accordion', $attributes, [
+	Helpers::props('accordion', $attributes, [
 		'accordionContent' => $innerBlockContent
 	])
 );
 
-echo ProjectVendor\EightshiftLibs\Helpers\Components::render( // OK (FQCN)
+echo ProjectVendor\EightshiftLibs\Helpers\Helpers::render( // OK (FQCN)
 	'accordion',
-	Components::props('accordion', $attributes, [
+	Helpers::props('accordion', $attributes, [
 		'accordionContent' => $innerBlockContent
 	])
 );
 
-echo Components::outputCssVariables($attributes, $manifest, $unique, $globalManifest); // OK (import)
+echo Helpers::outputCssVariables($attributes, $manifest, $unique, $globalManifest); // OK (import)
 
-echo \Components::outputCssVariables($attributes, $manifest, $unique, $globalManifest); // Bad (global namespaced class)
+echo \Helpers::outputCssVariables($attributes, $manifest, $unique, $globalManifest); // Bad (global namespaced class)
 
-echo Components::getManifest($attributes, $manifest, $unique, $globalManifest); // Bad (Not on the safe method list)
+echo Helpers::getManifest($attributes, $manifest, $unique, $globalManifest); // Bad (Not on the safe method list)

--- a/Eightshift/Tests/Security/ComponentsEscapeUnitTest.2.inc
+++ b/Eightshift/Tests/Security/ComponentsEscapeUnitTest.2.inc
@@ -1,26 +1,26 @@
 <?php
 
-echo Components::render( // Bad. Not the lib's helper, no import.
+echo Helpers::render( // Bad. Not the lib's helper, no import.
 	'accordion',
-	Components::props('accordion', $attributes, [
+	Helpers::props('accordion', $attributes, [
 		'accordionContent' => $innerBlockContent
 	])
 );
 
-echo MyClass\Components::render( // Bad. Not the lib's helper.
+echo MyClass\Helpers::render( // Bad. Not the lib's helper.
 	'accordion',
-	Components::props('accordion', $attributes, [
+	Helpers::props('accordion', $attributes, [
 		'accordionContent' => $innerBlockContent
 	])
 );
 
-echo Components::props('accordion', $attributes, [ // Bad. Not safe method.
+echo Helpers::props('accordion', $attributes, [ // Bad. Not safe method.
 	'accordionContent' => $innerBlockContent
 ]);
 
-echo ProjectVendor\EightshiftLibs\Helpers\Components::render( // OK (FQCN)
+echo ProjectVendor\EightshiftLibs\Helpers\Helpers::render( // OK (FQCN)
 	'accordion',
-	Components::props('accordion', $attributes, [
+	Helpers::props('accordion', $attributes, [
 		'accordionContent' => $innerBlockContent
 	])
 );

--- a/Eightshift/Tests/Security/ComponentsEscapeUnitTest.3.inc
+++ b/Eightshift/Tests/Security/ComponentsEscapeUnitTest.3.inc
@@ -2,21 +2,21 @@
 
 use ProjectVendor\EightshiftLibs\Helpers;
 
-echo Helpers\Components::render( // OK (imported method, even though not correctly, it's still valid)
+echo Helpers\Helpers::render( // OK (imported method, even though not correctly, it's still valid)
 	'accordion',
-	Components::props('accordion', $attributes, [
+	Helpers::props('accordion', $attributes, [
 		'accordionContent' => $innerBlockContent
 	])
 );
 
-echo Components::render( // Bad (Not correctly imported)
+echo Helpers::render( // Bad (Not correctly imported)
 	'accordion',
-	Components::props('accordion', $attributes, [
+	Helpers::props('accordion', $attributes, [
 		'accordionContent' => $innerBlockContent
 	])
 );
 
-echo (new Components())->render( // Bad
+echo (new Helpers())->render( // Bad
 	'accordion',
 	[]
 );

--- a/Eightshift/Tests/Security/ComponentsEscapeUnitTest.4.inc
+++ b/Eightshift/Tests/Security/ComponentsEscapeUnitTest.4.inc
@@ -6,19 +6,19 @@
  * @package EightshiftBoilerplate
  */
 
-use EightshiftBoilerplateVendor\EightshiftLibs\Helpers\Components;
+use EightshiftBoilerplateVendor\EightshiftLibs\Helpers\Helpers;
 
-$manifest = Components::getManifest(__DIR__);
+$manifest = Helpers::getManifest(__DIR__);
 
 // Used to add or remove wrapper.
-$wrapperUse = Components::checkAttr('wrapperUse', $attributes, $manifest);
-$wrapperUseSimple = Components::checkAttr('wrapperUseSimple', $attributes, $manifest);
-$wrapperDisable = Components::checkAttr('wrapperDisable', $attributes, $manifest);
-$wrapperParentClass = Components::checkAttr('wrapperParentClass', $attributes, $manifest);
-$className = Components::checkAttr('className', $attributes, $manifest);
+$wrapperUse = Helpers::checkAttr('wrapperUse', $attributes, $manifest);
+$wrapperUseSimple = Helpers::checkAttr('wrapperUseSimple', $attributes, $manifest);
+$wrapperDisable = Helpers::checkAttr('wrapperDisable', $attributes, $manifest);
+$wrapperParentClass = Helpers::checkAttr('wrapperParentClass', $attributes, $manifest);
+$className = Helpers::checkAttr('className', $attributes, $manifest);
 
-$wrapperParentClassItemClass = Components::selector($wrapperParentClass, $wrapperParentClass, 'item');
-$wrapperParentClassItemInnerClass = Components::selector($wrapperParentClass, $wrapperParentClass, 'item-inner');
+$wrapperParentClassItemClass = Helpers::selector($wrapperParentClass, $wrapperParentClass, 'item');
+$wrapperParentClassItemInnerClass = Helpers::selector($wrapperParentClass, $wrapperParentClass, 'item-inner');
 
 if (!$wrapperUse || $wrapperDisable) {
 	if ($wrapperParentClass) {
@@ -44,50 +44,50 @@ if (!$wrapperUse || $wrapperDisable) {
 	return;
 }
 
-$wrapperId = Components::checkAttr('wrapperId', $attributes, $manifest);
-$wrapperAnchorId = Components::checkAttr('wrapperAnchorId', $attributes, $manifest);
-$wrapperBackgroundColor = Components::checkAttr('wrapperBackgroundColor', $attributes, $manifest);
+$wrapperId = Helpers::checkAttr('wrapperId', $attributes, $manifest);
+$wrapperAnchorId = Helpers::checkAttr('wrapperAnchorId', $attributes, $manifest);
+$wrapperBackgroundColor = Helpers::checkAttr('wrapperBackgroundColor', $attributes, $manifest);
 
-$wrapperHide = Components::checkAttrResponsive('wrapperHide', $attributes, $manifest);
-$wrapperSpacingTop = Components::checkAttrResponsive('wrapperSpacingTop', $attributes, $manifest);
-$wrapperSpacingBottom = Components::checkAttrResponsive('wrapperSpacingBottom', $attributes, $manifest);
-$wrapperSpacingTopIn = Components::checkAttrResponsive('wrapperSpacingTopIn', $attributes, $manifest);
-$wrapperSpacingBottomIn = Components::checkAttrResponsive('wrapperSpacingBottomIn', $attributes, $manifest);
-$wrapperDividerTop = Components::checkAttrResponsive('wrapperDividerTop', $attributes, $manifest);
-$wrapperDividerBottom = Components::checkAttrResponsive('wrapperDividerBottom', $attributes, $manifest);
-$wrapperContainerWidth = Components::checkAttrResponsive('wrapperContainerWidth', $attributes, $manifest);
-$wrapperGutter = Components::checkAttrResponsive('wrapperGutter', $attributes, $manifest);
-$wrapperWidth = Components::checkAttrResponsive('wrapperWidth', $attributes, $manifest);
-$wrapperOffset = Components::checkAttrResponsive('wrapperOffset', $attributes, $manifest);
+$wrapperHide = Helpers::checkAttrResponsive('wrapperHide', $attributes, $manifest);
+$wrapperSpacingTop = Helpers::checkAttrResponsive('wrapperSpacingTop', $attributes, $manifest);
+$wrapperSpacingBottom = Helpers::checkAttrResponsive('wrapperSpacingBottom', $attributes, $manifest);
+$wrapperSpacingTopIn = Helpers::checkAttrResponsive('wrapperSpacingTopIn', $attributes, $manifest);
+$wrapperSpacingBottomIn = Helpers::checkAttrResponsive('wrapperSpacingBottomIn', $attributes, $manifest);
+$wrapperDividerTop = Helpers::checkAttrResponsive('wrapperDividerTop', $attributes, $manifest);
+$wrapperDividerBottom = Helpers::checkAttrResponsive('wrapperDividerBottom', $attributes, $manifest);
+$wrapperContainerWidth = Helpers::checkAttrResponsive('wrapperContainerWidth', $attributes, $manifest);
+$wrapperGutter = Helpers::checkAttrResponsive('wrapperGutter', $attributes, $manifest);
+$wrapperWidth = Helpers::checkAttrResponsive('wrapperWidth', $attributes, $manifest);
+$wrapperOffset = Helpers::checkAttrResponsive('wrapperOffset', $attributes, $manifest);
 
 $componentClass = 'wrapper';
 
-$wrapperClass = Components::classnames([
+$wrapperClass = Helpers::classnames([
 	$componentClass,
-	Components::selector($componentClass, $componentClass, 'bg-color', $wrapperBackgroundColor), // @phpstan-ignore-line
-	Components::responsiveSelectors($wrapperSpacingTop, 'spacing-top', $componentClass),
-	Components::responsiveSelectors($wrapperSpacingBottom, 'spacing-bottom', $componentClass),
-	Components::responsiveSelectors($wrapperSpacingTopIn, 'spacing-top-in', $componentClass),
-	Components::responsiveSelectors($wrapperSpacingBottomIn, 'spacing-bottom-in', $componentClass),
-	Components::responsiveSelectors($wrapperDividerTop, 'divider-top', $componentClass, false),
-	Components::responsiveSelectors($wrapperDividerBottom, 'divider-bottom', $componentClass, false),
-	Components::responsiveSelectors($wrapperHide, 'hide', $componentClass, false),
+	Helpers::selector($componentClass, $componentClass, 'bg-color', $wrapperBackgroundColor), // @phpstan-ignore-line
+	Helpers::responsiveSelectors($wrapperSpacingTop, 'spacing-top', $componentClass),
+	Helpers::responsiveSelectors($wrapperSpacingBottom, 'spacing-bottom', $componentClass),
+	Helpers::responsiveSelectors($wrapperSpacingTopIn, 'spacing-top-in', $componentClass),
+	Helpers::responsiveSelectors($wrapperSpacingBottomIn, 'spacing-bottom-in', $componentClass),
+	Helpers::responsiveSelectors($wrapperDividerTop, 'divider-top', $componentClass, false),
+	Helpers::responsiveSelectors($wrapperDividerBottom, 'divider-bottom', $componentClass, false),
+	Helpers::responsiveSelectors($wrapperHide, 'hide', $componentClass, false),
 	$className,
 ]);
 
-$wrapperContainerClass = Components::classnames([
-	Components::selector($componentClass, $componentClass, 'container'), // @phpstan-ignore-line
-	Components::responsiveSelectors($wrapperContainerWidth, 'container-width', $componentClass),
-	Components::responsiveSelectors($wrapperGutter, 'gutter', $componentClass),
+$wrapperContainerClass = Helpers::classnames([
+	Helpers::selector($componentClass, $componentClass, 'container'), // @phpstan-ignore-line
+	Helpers::responsiveSelectors($wrapperContainerWidth, 'container-width', $componentClass),
+	Helpers::responsiveSelectors($wrapperGutter, 'gutter', $componentClass),
 ]);
 
-$wrapperInnerClass = Components::classnames([
-	Components::selector($componentClass, $componentClass, 'inner'), // @phpstan-ignore-line
-	Components::responsiveSelectors($wrapperWidth, 'width', $componentClass),
-	Components::responsiveSelectors($wrapperOffset, 'offset', $componentClass),
+$wrapperInnerClass = Helpers::classnames([
+	Helpers::selector($componentClass, $componentClass, 'inner'), // @phpstan-ignore-line
+	Helpers::responsiveSelectors($wrapperWidth, 'width', $componentClass),
+	Helpers::responsiveSelectors($wrapperOffset, 'offset', $componentClass),
 ]);
 
-$wrapperMainAnchorClass = Components::selector($componentClass, $componentClass, 'anchor'); // @phpstan-ignore-line
+$wrapperMainAnchorClass = Helpers::selector($componentClass, $componentClass, 'anchor'); // @phpstan-ignore-line
 
 $idOutput = '';
 

--- a/Eightshift/Tests/Security/ComponentsEscapeUnitTest.5.inc
+++ b/Eightshift/Tests/Security/ComponentsEscapeUnitTest.5.inc
@@ -6,44 +6,44 @@
  * @package EightshiftForms
  */
 
-// phpcs:set Eightshift.Security.ComponentsEscape overriddenClass EightshiftForms\\Helpers\\Components
+// phpcs:set Eightshift.Security.HelpersEscape overriddenClass EightshiftForms\\Helpers\\Helpers
 
 use EightshiftForms\AdminMenus\FormSettingsAdminSubMenu;
 use EightshiftForms\CustomPostType\Forms;
 use EightshiftForms\Geolocation\Geolocation;
 use EightshiftForms\Geolocation\SettingsGeolocation;
-use EightshiftForms\Helpers\Components;
+use EightshiftForms\Helpers\Helpers;
 use EightshiftForms\Helpers\Helper;
 use EightshiftForms\Manifest\Manifest;
 use EightshiftForms\Settings\Settings\SettingsGeneral;
 
-$manifest = Components::getManifest(__DIR__);
-$globalManifest = Components::getManifest(dirname(__DIR__, 2));
-$manifestInvalid = Components::getManifest(dirname(__DIR__, 2) . '/components/invalid');
+$manifest = Helpers::getManifest(__DIR__);
+$globalManifest = Helpers::getManifest(dirname(__DIR__, 2));
+$manifestInvalid = Helpers::getManifest(dirname(__DIR__, 2) . '/components/invalid');
 
 if (!$this->isCheckboxOptionChecked(SettingsGeneral::SETTINGS_GENERAL_DISABLE_DEFAULT_ENQUEUE_SCRIPT_KEY, SettingsGeneral::SETTINGS_GENERAL_DISABLE_DEFAULT_ENQUEUE_KEY)) {
-	echo Components::outputCssVariablesGlobal($globalManifest); // Bad.
+	echo Helpers::outputCssVariablesGlobal($globalManifest); // Bad.
 }
 
 $blockClass = $attributes['blockClass'] ?? '';
 $invalidClass = $manifestInvalid['componentClass'] ?? '';
 
 // Check formPost ID prop.
-$formsFormPostId = Components::checkAttr('formsFormPostId', $attributes, $manifest);
-$formsStyle = Components::checkAttr('formsStyle', $attributes, $manifest);
-$formsServerSideRender = Components::checkAttr('formsServerSideRender', $attributes, $manifest);
-$formsFormDataTypeSelector = Components::checkAttr('formsFormDataTypeSelector', $attributes, $manifest);
-$formsFormGeolocation = Components::checkAttr('formsFormGeolocation', $attributes, $manifest);
-$formsFormGeolocationAlternatives = Components::checkAttr('formsFormGeolocationAlternatives', $attributes, $manifest);
+$formsFormPostId = Helpers::checkAttr('formsFormPostId', $attributes, $manifest);
+$formsStyle = Helpers::checkAttr('formsStyle', $attributes, $manifest);
+$formsServerSideRender = Helpers::checkAttr('formsServerSideRender', $attributes, $manifest);
+$formsFormDataTypeSelector = Helpers::checkAttr('formsFormDataTypeSelector', $attributes, $manifest);
+$formsFormGeolocation = Helpers::checkAttr('formsFormGeolocation', $attributes, $manifest);
+$formsFormGeolocationAlternatives = Helpers::checkAttr('formsFormGeolocationAlternatives', $attributes, $manifest);
 
 // Override form ID in case we use geolocation but use this feature only on frontend.
 if (!$formsServerSideRender) {
 	$formsFormPostId = \apply_filters(Geolocation::GEOLOCATION_IS_USER_LOCATED, $formsFormPostId, $formsFormGeolocation, $formsFormGeolocationAlternatives);
 }
 
-$formsClass = Components::classnames([
-	Components::selector($blockClass, $blockClass),
-	Components::selector($formsStyle, $blockClass, '', $formsStyle),
+$formsClass = Helpers::classnames([
+	Helpers::selector($blockClass, $blockClass),
+	Helpers::selector($formsStyle, $blockClass, '', $formsStyle),
 	$attributes['className'] ?? '',
 ]);
 
@@ -56,7 +56,7 @@ if (!$formsServerSideRender && (!$formsFormPostId || get_post_status($formsFormP
 if ($formsServerSideRender) {
 	// Missing form ID.
 	if (!$formsFormPostId) {
-		$formsClassNotSet = Components::selector($blockClass, $blockClass, '', 'not-set');
+		$formsClassNotSet = Helpers::selector($blockClass, $blockClass, '', 'not-set');
 		?>
 			<div class="<?php echo esc_attr($formsClass); ?> <?php echo esc_attr($formsClassNotSet); ?>">
 				<img class="<?php echo esc_attr("{$blockClass}__image") ?>" src="<?php echo esc_url(\apply_filters(Manifest::MANIFEST_ITEM, 'cover.png')); ?>" />
@@ -69,7 +69,7 @@ if ($formsServerSideRender) {
 
 	// Not published or removed at somepoint.
 	if (get_post_status($formsFormPostId) !== 'publish') {
-		$formsClassNotPublished = Components::selector($blockClass, $invalidClass);
+		$formsClassNotPublished = Helpers::selector($blockClass, $invalidClass);
 		?>
 			<div class="<?php echo esc_attr($formsClass); ?> <?php echo esc_attr($formsClassNotPublished); ?>">
 				<svg width="20" height="20" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">
@@ -125,14 +125,14 @@ if ($formsServerSideRender) {
 
 			if (isset($block['innerBlocks'])) {
 				foreach ($block['innerBlocks'] as $innerKey => $innerBlock) {
-					$blockName = Components::kebabToCamelCase(explode('/', $innerBlock['blockName'])[1]);
+					$blockName = Helpers::kebabToCamelCase(explode('/', $innerBlock['blockName'])[1]);
 					$blocks[$key]['innerBlocks'][$innerKey]['attrs']["{$blockName}FormPostId"] = $formsFormPostId;
 					$blocks[$key]['innerBlocks'][$innerKey]['attrs']["{$blockName}FormDataTypeSelector"] = $formsFormDataTypeSelector;
 					$blocks[$key]['innerBlocks'][$innerKey]['attrs']["{$blockName}FormServerSideRender"] = $formsServerSideRender;
 
 					if (isset($innerBlock['innerBlocks'])) {
 						foreach ($innerBlock['innerBlocks'] as $inKey => $inBlock) {
-							$name = Components::kebabToCamelCase(explode('/', $inBlock['blockName'])[1]);
+							$name = Helpers::kebabToCamelCase(explode('/', $inBlock['blockName'])[1]);
 
 							if ($name === 'submit') {
 								$blocks[$key]['innerBlocks'][$innerKey]['innerBlocks'][$inKey]['attrs']["{$name}SubmitServerSideRender"] = $formsServerSideRender;
@@ -147,9 +147,9 @@ if ($formsServerSideRender) {
 	// Render blocks.
 	foreach ($blocks as $block) {
 		echo \apply_filters('the_content', \render_block($block)); // Bad.
-        echo Components::render( // Ok.
+        echo Helpers::render( // Ok.
             'accordion',
-            Components::props('accordion', $attributes, [
+            Helpers::props('accordion', $attributes, [
                 'accordionContent' => $innerBlockContent
             ])
         );
@@ -159,4 +159,4 @@ if ($formsServerSideRender) {
 
 <?php
 
-// phpcs:set Eightshift.Security.ComponentsEscape overriddenClass ''
+// phpcs:set Eightshift.Security.HelpersEscape overriddenClass ''

--- a/Eightshift/Tests/Security/ComponentsEscapeUnitTest.6.inc
+++ b/Eightshift/Tests/Security/ComponentsEscapeUnitTest.6.inc
@@ -1,16 +1,16 @@
 <?php
 
-// phpcs:set Eightshift.Security.ComponentsEscape allowedMethods[] props
+// phpcs:set Eightshift.Security.HelpersEscape allowedMethods[] props
 
-echo MyClass\Components::render( // Bad. Not the lib's helper.
+echo MyClass\Helpers::render( // Bad. Not the lib's helper.
 	'accordion',
-	Components::props('accordion', $attributes, [ // Ok. Allowed. And the sniff will skip checking the inside of the static method.
+	Helpers::props('accordion', $attributes, [ // Ok. Allowed. And the sniff will skip checking the inside of the static method.
 		'accordionContent' => $innerBlockContent
 	])
 );
 
-Components::props('accordion', $attributes, [ // Ok. Allowed.
+Helpers::props('accordion', $attributes, [ // Ok. Allowed.
 	'accordionContent' => $innerBlockContent
 ]);
 
-// phpcs:set Eightshift.Security.ComponentsEscape allowedMethods[] render, outputCssVariables
+// phpcs:set Eightshift.Security.HelpersEscape allowedMethods[] render, outputCssVariables

--- a/Eightshift/Tests/Security/ComponentsEscapeUnitTest.php
+++ b/Eightshift/Tests/Security/ComponentsEscapeUnitTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * Unit test class for ComponentsEscape sniff.
+ * Unit test class for HelpersEscape sniff.
  *
  * @package EightshiftCS
  *
@@ -17,11 +17,11 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
 /**
  * Unit test class for the FunctionCommentUnitTest sniff.
  *
- * @covers \EightshiftCS\Eightshift\Sniffs\Security\ComponentsEscapeSniff
+ * @covers \EightshiftCS\Eightshift\Sniffs\Security\HelpersEscapeSniff
  *
  * @since 1.4.0 Added $testFile parameter.
  */
-class ComponentsEscapeUnitTest extends AbstractSniffUnitTest
+class HelpersEscapeUnitTest extends AbstractSniffUnitTest
 {
 	/**
 	 * Returns the lines where errors should occur.
@@ -33,33 +33,33 @@ class ComponentsEscapeUnitTest extends AbstractSniffUnitTest
 	public function getErrorList(string $testFile = ''): array
 	{
 		switch ($testFile) {
-			case 'ComponentsEscapeUnitTest.1.inc':
+			case 'HelpersEscapeUnitTest.1.inc':
 				return [
 					21 => 1,
 					23 => 1,
 				];
-			case 'ComponentsEscapeUnitTest.2.inc':
+			case 'HelpersEscapeUnitTest.2.inc':
 				return [
 					3 => 1,
 					10 => 1,
 					17 => 1
 				];
-			case 'ComponentsEscapeUnitTest.3.inc':
+			case 'HelpersEscapeUnitTest.3.inc':
 				return [
 					12 => 1,
 					19 => 1,
 					24 => 1,
 				];
-			case 'ComponentsEscapeUnitTest.4.inc':
+			case 'HelpersEscapeUnitTest.4.inc':
 				return [
 					102 => 1,
 				];
-			case 'ComponentsEscapeUnitTest.5.inc':
+			case 'HelpersEscapeUnitTest.5.inc':
 				return [
 					25 => 1,
 					149 => 1,
 				];
-			case 'ComponentsEscapeUnitTest.6.inc':
+			case 'HelpersEscapeUnitTest.6.inc':
 				return [
 					5 => 1,
 				];

--- a/Tests/RulesetCheck/RulesetTest7.inc
+++ b/Tests/RulesetCheck/RulesetTest7.inc
@@ -8,20 +8,20 @@
 
 namespace Project;
 
-use ProjectVendor\EightshiftLibs\Helpers\Components;
+use ProjectVendor\EightshiftLibs\Helpers\Helpers;
 
-$manifest = Components::getManifest(__DIR__);
+$manifest = Helpers::getManifest(__DIR__);
 $componentName = $attributes['componentName'] ?? $manifest['componentName'];
 
-$mainTitle = Components::checkAttr('title', $attributes, $manifest, $componentName);
-$nonceField = Components::checkAttr('nonceField', $attributes, $manifest, $componentName);
+$mainTitle = Helpers::checkAttr('title', $attributes, $manifest, $componentName);
+$nonceField = Helpers::checkAttr('nonceField', $attributes, $manifest, $componentName);
 
-$classname = Components::classnames([
+$classname = Helpers::classnames([
 	'some-class',
 	'other-class-name'
 ]);
 
-echo Components::classnames([ // phpcs:ignore
+echo Helpers::classnames([ // phpcs:ignore
 	'some-class',
 	'other-class-name'
 ]);
@@ -30,11 +30,11 @@ echo Components::classnames([ // phpcs:ignore
 <div class="wrap bulk-email js-bulk-mail-send">
 	<div class="bulk-email__wrapper">
 		<?php
-		echo Components::render('heading', [ // phpcs:ignore
+		echo Helpers::render('heading', [ // phpcs:ignore
 			'headingLevel' => 1,
 			'headingContent' => $mainTitle
 		]),
-		Components::render('paragraph', [ // phpcs:ignore
+		Helpers::render('paragraph', [ // phpcs:ignore
 			'paragraphContent' => \esc_html__(
 				'Use the form below to send the bulk emails to conference attendees.',
 				'project'

--- a/Tests/RulesetCheck/RulesetTest8.inc
+++ b/Tests/RulesetCheck/RulesetTest8.inc
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * Helpers for components
+ * Helpers for helpers
  *
  * @package EightshiftLibs\Helpers
  */
@@ -14,12 +14,12 @@ use EightshiftLibs\Exception\ComponentException;
 use Exception;
 
 /**
- * Helpers for components
+ * Helpers for helpers
  */
-class Components
+class Helpers
 {
 	/**
-	 * Makes sure the output is string. Useful for converting an array of components into a string.
+	 * Makes sure the output is string. Useful for converting an array of helpers into a string.
 	 * If you pass an associative array it will output strings with keys,
 	 * used for generating data-attributes from array.
 	 *
@@ -64,7 +64,7 @@ class Components
 	}
 
 	/**
-	 * Renders a components and (optionally) passes some attributes to it.
+	 * Renders a helpers and (optionally) passes some attributes to it.
 	 *
 	 * Note about "parentClass" attribute: If provided, the component will be wrapped with a
 	 * parent BEM selector. For example, if $attributes['parentClass'] === 'header' and $component === 'logo'
@@ -187,7 +187,7 @@ class Components
 	 * Create responsive selectors used for responsive attributes.
 	 *
 	 * Example:
-	 * Components::responsiveSelectors($attributes['width'], 'width', $block_class);
+	 * Helpers::responsiveSelectors($attributes['width'], 'width', $block_class);
 	 *
 	 * Output:
 	 * block-column__width-large--4


### PR DESCRIPTION
### Changed
- Components helpers in the new eightshift-libs@8.0.0 is deprecated and removed. Instead `Helpers` is used. The `Eightshift.Security.ComponentsEscape` sniff is updated and renamed to `Eightshift.Security.HelpersEscape` to reflect this change.