### PR TITLE
Update PHP_CodeSniffer repository link and schema URL

### DIFF
--- a/Eightshift/ruleset.xml
+++ b/Eightshift/ruleset.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<ruleset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="Eightshift" namespace="EightshiftCS\Eightshift" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/squizlabs/PHP_CodeSniffer/master/phpcs.xsd">
+<ruleset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="Eightshift" namespace="EightshiftCS\Eightshift" xsi:noNamespaceSchemaLocation="https://schema.phpcodesniffer.com/phpcs.xsd">
 	<description>Eightshift coding standards for WordPress projects</description>
 
 	<config name="encoding" value="utf-8"/>

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 # Eightshift Coding Standards for WordPress
 
 This package contains [Eightshift Coding Standards for WordPress](https://handbook.infinum.co/books/wordpress) for
- [PHP_CodeSniffer](https://github.com/squizlabs/PHP_CodeSniffer/). The intention of this package is to have a unified
+ [PHP_CodeSniffer](https://github.com/PHPCSStandards/PHP_CodeSniffer/). The intention of this package is to have a unified
   code across the WordPress projects we do at Eightshift, and to help with the code review.
 
 ## Installation

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <ruleset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="Eightshift Coding Standards for WordPress"
-		 xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/squizlabs/PHP_CodeSniffer/master/phpcs.xsd">
+		 xsi:noNamespaceSchemaLocation="https://schema.phpcodesniffer.com/phpcs.xsd">
 
 	<description>The coding standards used when writing Eightshift Coding Standards itself</description>
 

--- a/phpcs.xml.dist.sample
+++ b/phpcs.xml.dist.sample
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<ruleset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="Example Project" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/squizlabs/PHP_CodeSniffer/master/phpcs.xsd">
+<ruleset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="Example Project" xsi:noNamespaceSchemaLocation="https://schema.phpcodesniffer.com/phpcs.xsd">
 
 	<description>A custom set of rules to check for a WordPress project running Eightshift coding standards for WP.
 	</description>


### PR DESCRIPTION
PHP_CodeSniffer has moved to a new GitHub organization. The \`squizlabs/PHP_CodeSniffer\` repository is now archived and the project is actively maintained at https://github.com/PHPCSStandards/PHP_CodeSniffer.

Additionally, PHP_CodeSniffer now provides a canonical permalink for the XML schema used in the \`xsi:noNamespaceSchemaLocation\` attribute of ruleset files. This replaces the previous \`raw.githubusercontent.com\` URL with https://schema.phpcodesniffer.com/phpcs.xsd.

See:
* https://github.com/squizlabs/PHP_CodeSniffer/issues/3932
* https://github.com/PHPCSStandards/PHP_CodeSniffer/issues/1094